### PR TITLE
Update documentation on using redis-connection with env2

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ require('env2')('config.env');
 var redisClient = require('redis-connection')();
 // now use your redis connection
 ```
+**Be sure you have defined an environment variable named "REDIS_URL"**
+
+```
+REDIS_URL=redis://127.0.0.1:6379/0
+```
+If the REDIS_URL environment variable is not defined `redis-connection` will use the Redis localhost url (127.0.0.1) on the port 6379
 
 ## Need More?
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,9 @@ require('env2')('config.env');
 var redisClient = require('redis-connection')();
 // now use your redis connection
 ```
-**Be sure you have defined an environment variable named "REDIS_URL"**
+**Make sure you have defined an environment variable named "REDIS_URL"**
+
+For example:
 
 ```
 REDIS_URL=redis://127.0.0.1:6379/0

--- a/index.js
+++ b/index.js
@@ -2,8 +2,8 @@ var redis = require('redis');
 var url   = require('url');
 
 var rc; // redis config
-if (process.env.REDISCLOUD_URL) {
-  var redisURL = url.parse(process.env.REDISCLOUD_URL);
+if (process.env.REDIS_URL) {
+  var redisURL = url.parse(process.env.REDIS_URL);
   rc = {
     port: redisURL.port,
     host: redisURL.hostname,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-connection",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Re-use a single or pool of redis connections across several modules/files in your app.",
   "main": "index.js",
   "scripts": {

--- a/test/local_redis.test.js
+++ b/test/local_redis.test.js
@@ -1,6 +1,6 @@
 require('env2')('config.env');
-var REDISCLOUD_URL = process.env.REDISCLOUD_URL;
-delete process.env.REDISCLOUD_URL; // delete to ensure we use LOCAL Redis!
+var REDIS_URL = process.env.REDIS_URL;
+delete process.env.REDIS_URL; // delete to ensure we use LOCAL Redis!
 
 var test    = require('tape');
 var decache = require('decache');          // http://goo.gl/JIjK9Y
@@ -46,11 +46,11 @@ test('Require an existing Redis SUBSCRIBER connectiong', function(t){
   });
 });
 
-test('Restore REDISCLOUD_URL for Heroku Compatibility tests', function(t){
+test('Restore REDIS_URL for Heroku Compatibility tests', function(t){
   redisClient.end();   // ensure redis con closed!
   redisSub.end();
   decache('../index.js');
   t.equal(redisClient.connected, false,  "✓ Connection to LOCAL Closed");
-  process.env.REDISCLOUD_URL = REDISCLOUD_URL; // restore for next text!
+  process.env.REDIS_URL = REDIS_URL; // restore for next text!
   t.end();
 });

--- a/test/rediscloud.test.js
+++ b/test/rediscloud.test.js
@@ -3,17 +3,17 @@ var test    = require('tape');
 var dir     = __dirname.split('/')[__dirname.split('/').length-1];
 var file    = dir + __filename.replace(__dirname, '') + " -> ";
 
-test(file + " Confirm RedisCloud is accessible GET/SET", function(t) {
+test(file + " Confirm remote Redis is accessible GET/SET", function(t) {
   // require('env2')('config.env');
-  console.log(process.env.REDISCLOUD_URL);
+  console.log(process.env.REDIS_URL);
   var redisClient = require('../index.js')();
   redisClient.set('redis', 'working');
   // console.log("✓ Redis Client connected to: " + redisClient.address);
   t.ok(redisClient.address !== '127.0.0.1:6379', "✓ Redis Client connected to: " + redisClient.address)
   redisClient.get('redis', function (err, reply) {
-    t.equal(reply.toString(), 'working', '✓ RedisCLOUD is ' + reply.toString());
+    t.equal(reply.toString(), 'working', '✓ remote Redis is ' + reply.toString());
     redisClient.end();   // ensure redis con closed! - \\
-    t.equal(redisClient.connected, false, "✓ Connection to RedisCloud Closed");
+    t.equal(redisClient.connected, false, "✓ Connection to remote Redis Closed");
     t.end();
   });
 });


### PR DESCRIPTION
update the documentation and update the tests to use the REDIS_URL environment variable instead of the REDISCLOUD_URL name see [issue 13](https://github.com/dwyl/redis-connection/issues/13)
