### PR TITLE
add documentation for required environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,12 @@ require('env2')('.env'); // load the redis URL
 var redisClient = require('redis-connection')();
 // now use your redis connection
 ```
+**Make sure you have defined an environment variable named "REDIS_URL" or "REDISCLOUD_URL"**
+For example:
+```
+REDIS_URL=redis://127.0.0.1:6379/0
+```
+If the `REDIS_URL` (or `REDISCLOUD_URL`) environment variable is not defined `redis-connection` will use the Redis localhost url (127.0.0.1) on the port 6379
 
 ## Need More?
 

--- a/index.js
+++ b/index.js
@@ -2,8 +2,8 @@ var redis = require('redis');
 var url   = require('url');
 
 var rc; // redis config
-if (process.env.REDISCLOUD_URL) {
-  var redisURL = url.parse(process.env.REDISCLOUD_URL);
+if (process.env.REDIS_URL || process.env.REDISCLOUD_URL) {
+  var redisURL = url.parse(process.env.REDIS_URL || process.env.REDISCLOUD_URL);
   rc = {
     port: redisURL.port,
     host: redisURL.hostname,
@@ -22,7 +22,7 @@ var CON = {}; // store redis connections as Object
 
 function new_connection () {
     var redis_con = redis.createClient(rc.port, rc.host);
-    if (process.env.REDISCLOUD_URL && rc.auth) { // only auth on CI/Stage/Prod 
+    if (process.env.REDISCLOUD_URL && rc.auth) { // only auth on CI/Stage/Prod
       redis_con.auth(rc.auth);        // see: https://git.io/vH3TN
     }
     return redis_con;
@@ -60,13 +60,13 @@ module.exports.killall = function() {
  * @param {Object} err - the error Object thrown by Redis (standard node error)
  * @returns {Object} err - unmodified error
  */
-var reported; // bit 
+var reported; // bit
 function report_error (err) {
   if (!reported && err.syscall === 'connect' && err.code === 'ECONNREFUSED') {
     reported = true; // only report the error once.
     console.log('- - - - - - - - Redis Connection Error: - - - - - - - - ')
     console.error(err);
-    console.log('- - - - - - - - - - - - - - - - - - - - - - - - - - - - ')  
+    console.log('- - - - - - - - - - - - - - - - - - - - - - - - - - - - ')
   }
   return err;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-connection",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "Re-use a single or pool of redis connections across several modules/files in your app.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
ref: #13 and #14 

- Add documentation to signal that the `REDIS_URL` or `REDISCLOUD_URL` environment variable must be defined for this module to work

- Update the `index.js` to check if either of this environment variables are defined